### PR TITLE
Add MySQL support and modern Delphi project files

### DIFF
--- a/Code/RxCommon/Classes/Class_Database_Connections.pas
+++ b/Code/RxCommon/Classes/Class_Database_Connections.pas
@@ -11,18 +11,24 @@ const
       CMDBFILE      = 'Access File';
       CSERVER       = 'Server';
       CDATABASE     = 'DB';
-      CDATABASEPHYSSICALFILENAME = 'DB Physical File Name';
       CDATABASEBACKUPPATH = 'DB Backup Path';
       CUSER         = 'User';
       CPASSWORD     = 'Password';
       CINTSECURITY  = 'SSPI';
       CTRUE         = '#@$5%SdvB';
       CFALSE        = '%^6gFrd@34';
+      CPORT         = 'Port';
+      CDRIVER       = 'Driver';
+      CLEGACYDATABASEPHYSICALNAME = 'DB Physical File Name';
       DBFOLDER      = 'Data';
       DBBACKEXT     = '_DB.dat';
       DBBACKLOGEXT  = '_DBLog.dat';
       DBBACK        = '_DB';
       DBBACKLOG     = '_DBLog';
+
+      DEFAULT_MYSQL_DRIVER = 'MySQL ODBC 8.0 ANSI Driver';
+      DEFAULT_MYSQL_PORT   = 3306;
+      DEFAULT_ODBC_OPTIONS = 'Option=3';
 
 type
 
@@ -71,18 +77,23 @@ type
   TSQLConnection = class(TConnection)
   private
     FconnectionReady: Boolean;
-    FServer, FDatabase, FDatabasePhysicalFileName, FDatabaseBackupPath: string;
+    FServer, FDatabase, FDatabaseBackupPath: string;
     FuseIntegratedSecurity: Boolean;
+    FPort: Word;
+    FDriver: string;
+    FWarnedIntegratedSecurity: Boolean;
     function Getdatabase: string;
     function Getserver: string;
     function GetuseIntegratedSecurity: Boolean;
     procedure Setdatabase(const Value: string);
     procedure Setserver(const Value: string);
     procedure SetuseIntegratedSecurity(Value: Boolean);
-    function GetdatabasePhysicalFileName: string;
-    procedure SetdatabasePhysicalFileName(const Value: string);
     function GetdatabaseBackupPath: string;
     procedure SetdatabaseBackupPath(const Value: string);
+    function Getport: Word;
+    procedure Setport(const Value: Word);
+    function Getdriver: string;
+    procedure Setdriver(const Value: string);
   public
     constructor Create; override;
     function BuildConnectionString: string; override;
@@ -95,12 +106,12 @@ type
     property connectionReady: Boolean read FconnectionReady;
     property database: string read Getdatabase write Setdatabase;
     property server: string read Getserver write Setserver;
-    property useIntegratedSecurity: Boolean read GetuseIntegratedSecurity write 
+    property useIntegratedSecurity: Boolean read GetuseIntegratedSecurity write
         SetuseIntegratedSecurity;
-    property databasePhysicalFileName: string read GetdatabasePhysicalFileName 
-        write SetdatabasePhysicalFileName;
-    property databaseBackupPath: string read GetdatabaseBackupPath write 
+    property databaseBackupPath: string read GetdatabaseBackupPath write
         SetdatabaseBackupPath;
+    property port: Word read Getport write Setport;
+    property driver: string read Getdriver write Setdriver;
   end;
 
   TOracleConnection = class(TConnection)
@@ -555,8 +566,12 @@ begin (*.............................................................*)(*begin*)
 
   try
   inherited Create;
-  OLEDBProvider := 'SQLOLEDB.1';
+  OLEDBProvider := 'MSDASQL.1';
   FconnectionReady := False;
+  FPort := DEFAULT_MYSQL_PORT;
+  FDriver := DEFAULT_MYSQL_DRIVER;
+  FuseIntegratedSecurity := False;
+  FWarnedIntegratedSecurity := False;
   except
     on E:Exception do MessageDlg(e.Message, mtError, [mbOK], 0);
   end;
@@ -569,13 +584,8 @@ function TSQLConnection.BuildConnectionString: string; (*:::::::::::::::START:*)
                                                                                 (*===========================================*)
                                                                    (*14.9.2003*)(* Orig::Deane Putzier                       *)
 var (*.................................................................*)(*var*)(*...........................................*)
-  RetStr :string;
-  vPassword, vUsername, vDatabase, vServer :string;
-
-const                                                                  (*const*)(*...........................................*)
-  CONNSTR_0 = 'Provider=%s;Persist Security Info=False;User ID=%s;Initial Catalog=%s;Data Source=%s';
-  CONNSTR_1 = 'Provider=%s;Persist Security Info=False;Password=%s; User ID=%s;Initial Catalog=%s;Data Source=%s';
-  CONNSTR_2 = 'Provider=%s;Integrated Security=%s;Persist Security Info=False;Initial Catalog=%s;Data Source=%s';
+  RetStr, vPassword, vUsername, vDatabase, vServer, vDriver: string;
+  vPort: Word;
 
 begin (*.............................................................*)(*begin*)(*...........................................*)
 
@@ -587,14 +597,32 @@ begin (*.............................................................*)(*begin*)
   vUsername := GetUsername;
   vDatabase := GetDatabase;
   vServer   := GetServer;
+  vDriver   := Getdriver;
+  vPort     := Getport;
 
-  if GetuseIntegratedSecurity then
-    RetStr := Format(CONNSTR_2, [OLEDBProvider, 'SSPI', vDatabase, vServer])
-    else
-    if GetPassword <> '' then
-      RetStr := Format(CONNSTR_1, [OLEDBProvider, vPassword, vUsername, vDatabase, vServer])
-      else
-      RetStr := Format(CONNSTR_0, [OLEDBProvider, vUsername, vDatabase, vServer]);
+  GetuseIntegratedSecurity;
+
+  if Trim(vDriver) = '' then vDriver := DEFAULT_MYSQL_DRIVER;
+  if vPort = 0 then vPort := DEFAULT_MYSQL_PORT;
+
+  RetStr := Format('Provider=%s;Persist Security Info=False;Driver={%s};Server=%s;Port=%d',
+    [OLEDBProvider, vDriver, vServer, vPort]);
+
+  if vDatabase <> '' then
+    RetStr := RetStr + Format(';Database=%s', [vDatabase]);
+
+  if vUsername <> '' then
+    RetStr := RetStr + Format(';User=%s', [vUsername]);
+
+  if vPassword <> '' then
+    RetStr := RetStr + Format(';Password=%s', [vPassword]);
+
+  if Pos('Option=', AnsiUpperCase(RetStr)) = 0 then
+    RetStr := RetStr + Format(';%s', [DEFAULT_ODBC_OPTIONS]);
+
+  if RetStr[Length(RetStr)] <> ';' then
+    RetStr := RetStr + ';';
+
   Result := RetStr;
   FConnection.ConnectionString := Result;
   except
@@ -622,8 +650,8 @@ try
     MyConn.Database := GetDatabase;
     MyConn.UserName := GetUsername;
     MyConn.Password := GetPassword;
-    MyConn.integratedSecurity := GetuseIntegratedSecurity;
-    MyConn.PhysicalFileName := GetdatabasePhysicalFileName;
+    MyConn.integratedSecurity := False;
+    MyConn.Port := IntToStr(Getport);
     MyConn.BackupPath := GetdatabaseBackupPath;
 
     if MyConn.Connect(etSQL) then
@@ -631,7 +659,7 @@ try
       SetServer(MyConn.Server);
       SetDatabase(MyConn.Database);
       SetuseIntegratedSecurity(MyConn.integratedSecurity);
-      SetdatabasePhysicalFileName(MyConn.PhysicalFileName);
+      Setport(StrToIntDef(MyConn.Port, DEFAULT_MYSQL_PORT));
       SetdatabaseBackupPath(MyConn.BackupPath);
 
       // Changed Deane 2006- feb  Cleared values for user and password if using intergrated security
@@ -696,7 +724,16 @@ try
     begin
     RetVal := ReadStringFromRegistry(CINTSECURITY, True);
     if RetVal = CTRUE then
-      FuseIntegratedSecurity := True
+      begin
+      FuseIntegratedSecurity := False;
+      if not FWarnedIntegratedSecurity then
+        begin
+        MessageDlg('Integrated security is not supported for MySQL connections. '
+          + 'Credentials will be required instead.', mtWarning, [mbOK], 0);
+        FWarnedIntegratedSecurity := True;
+        end;
+      SaveStringToRegistry(CINTSECURITY, CFALSE, True);
+      end
       else
       FuseIntegratedSecurity := False;
     end;
@@ -733,7 +770,7 @@ begin (*.............................................................*)(*begin*)
 try
   FServer := Value;
   if FsaveToRegistry then SaveStringToRegistry(CSERVER, Value, False);
-//  BuildConnectionString;
+  BuildConnectionString;
 except
   on E:Exception do MessageDlg(e.Message, mtError, [mbOK], 0);
 end;
@@ -749,12 +786,13 @@ procedure TSQLConnection.SetuseIntegratedSecurity(Value: Boolean);
 begin
 
 try
-  FuseIntegratedSecurity := Value;
+  if Value then
+    FuseIntegratedSecurity := False
+    else
+    FuseIntegratedSecurity := False;
+
   if FsaveToRegistry then
-    if Value then
-      SaveStringToRegistry(CINTSECURITY, CTRUE, True)
-      else
-      SaveStringToRegistry(CINTSECURITY, CFALSE, True);
+    SaveStringToRegistry(CINTSECURITY, CFALSE, True);
 
   BuildConnectionString;
 except
@@ -782,57 +820,13 @@ end; (*................................................................*)(*end*)
 
 
 function TSQLConnection.Database_Backup: string;
-const
-  SQL_BD = 'USE Master EXEC sp_addumpdevice ''disk'', ''%s'',''%s''';
-  SQL_BK = 'BACKUP DATABASE %s TO %s';
-  SQL_BL = 'BACKUP LOG %s TO %s';
-
-
-var
-  SQL_E     :TADOCommand;
-  dbName, dbPath    :string;
-
 begin
 
-try
-  result := '';
-  SQL_E := TADOCommand.Create(Application);
-  with SQL_E do
-    try
-    dbName := Getdatabase;
-    dbPath := GetdatabaseBackupPath;
-    if not DirectoryExists(dbPath) then
-      if  not CreateDir(dbPath) then
-        raise Exception.Create('Cannot create ' + dbPath);
+  Result := '';
+  MessageDlg('Automated backup routines are not supported for MySQL connections. '
+    + 'Please use mysqldump or your preferred MySQL backup utility.',
+    mtInformation, [mbOK], 0);
 
-    SQL_E.ConnectionString := BuildConnectionString_WithoutDB;
-    CommandText := Format(SQL_BD, [dbName + DBBACK, dbPath + dbName + DBBACKEXT]);
-    Execute;
-    CommandText := Format(SQL_BD, [dbName + DBBACKLOG, dbPath + dbName + DBBACKLOGEXT]);
-    Execute;
-    CommandText := Format(SQL_BK, [dbName, dbName + DBBACK]);
-    Execute;
-    CommandText := Format(SQL_BL, [dbName, dbName + DBBACKLOG]);
-    Execute;
-    finally
-    end;
-except
-  on E:Exception do MessageDlg(e.Message, mtError, [mbOK], 0);
-end;
-
-end;
-
-function TSQLConnection.GetdatabasePhysicalFileName: string;
-begin
-  if FsaveToRegistry then FDatabasePhysicalFileName := ReadStringFromRegistry(CDATABASEPHYSSICALFILENAME, False);
-  Result := FDatabasePhysicalFileName;
-end;
-
-
-procedure TSQLConnection.SetdatabasePhysicalFileName(const Value: string);
-begin
-  FDatabasePhysicalFileName := Value;
-  if FsaveToRegistry then SaveStringToRegistry(CDATABASEPHYSSICALFILENAME, Value, False);
 end;
 
 function TSQLConnection.GetdatabaseBackupPath: string;
@@ -847,19 +841,86 @@ begin
   if FsaveToRegistry then SaveStringToRegistry(CDATABASEBACKUPPATH, Value, False);
 end;
 
+function TSQLConnection.Getport: Word;
+var
+  PortValue: string;
+begin
+  if FsaveToRegistry then
+    begin
+    PortValue := ReadStringFromRegistry(CPORT, False);
+    if PortValue = '' then
+      PortValue := ReadStringFromRegistry(CLEGACYDATABASEPHYSICALNAME, False);
+    if PortValue <> '' then
+      FPort := StrToIntDef(PortValue, DEFAULT_MYSQL_PORT);
+    end;
+
+  if FPort = 0 then
+    FPort := DEFAULT_MYSQL_PORT;
+
+  Result := FPort;
+end;
+
+procedure TSQLConnection.Setport(const Value: Word);
+var
+  StoredValue: string;
+begin
+  if Value = 0 then
+    FPort := DEFAULT_MYSQL_PORT
+    else
+    FPort := Value;
+
+  if FsaveToRegistry then
+    begin
+    StoredValue := IntToStr(FPort);
+    SaveStringToRegistry(CPORT, StoredValue, False);
+    end;
+
+  BuildConnectionString;
+end;
+
+function TSQLConnection.Getdriver: string;
+begin
+  if FsaveToRegistry then
+    begin
+    FDriver := ReadStringFromRegistry(CDRIVER, False);
+    if FDriver = '' then
+      FDriver := ReadStringFromRegistry(CLEGACYDATABASEPHYSICALNAME, False);
+    end;
+
+  if Trim(FDriver) = '' then
+    FDriver := DEFAULT_MYSQL_DRIVER;
+
+  if Length(FDriver) > 1 then
+    if (FDriver[1] = '{') and (FDriver[Length(FDriver)] = '}') then
+      FDriver := Copy(FDriver, 2, Length(FDriver) - 2);
+
+  Result := FDriver;
+end;
+
+procedure TSQLConnection.Setdriver(const Value: string);
+begin
+  FDriver := Trim(Value);
+  if FDriver = '' then
+    FDriver := DEFAULT_MYSQL_DRIVER;
+
+  if Length(FDriver) > 1 then
+    if (FDriver[1] = '{') and (FDriver[Length(FDriver)] = '}') then
+      FDriver := Copy(FDriver, 2, Length(FDriver) - 2);
+
+  if FsaveToRegistry then
+    SaveStringToRegistry(CDRIVER, FDriver, False);
+
+  BuildConnectionString;
+end;
+
 
 function TSQLConnection.BuildConnectionString_WithoutDB: string;
                                                                                 (*function:BuildConnectionString-------------*)
                                                                                 (*===========================================*)
                                                                    (*14.9.2003*)(* Orig::Deane Putzier                       *)
 var (*.................................................................*)(*var*)(*...........................................*)
-  RetStr :string;
-  vPassword, vUsername, vServer :string;
-
-const                                                                  (*const*)(*...........................................*)
-  CONNSTR_0 = 'Provider=%s;Persist Security Info=False;User ID=%s;Data Source=%s';
-  CONNSTR_1 = 'Provider=%s;Persist Security Info=False;Password=%s; User ID=%s;Data Source=%s';
-  CONNSTR_2 = 'Provider=%s;Integrated Security=%s;Persist Security Info=False;Data Source=%s';
+  RetStr, vPassword, vUsername, vServer, vDriver: string;
+  vPort: Word;
 
 begin (*.............................................................*)(*begin*)(*...........................................*)
 
@@ -870,14 +931,29 @@ try
   vPassword := GetPassword;
   vUsername := GetUsername;
   vServer   := GetServer;
+  vDriver   := Getdriver;
+  vPort     := Getport;
 
-  if GetuseIntegratedSecurity then
-    RetStr := Format(CONNSTR_2, [OLEDBProvider, 'SSPI', vServer])
-    else
-    if GetPassword <> '' then
-      RetStr := Format(CONNSTR_1, [OLEDBProvider, vPassword, vUsername, vServer])
-      else
-      RetStr := Format(CONNSTR_0, [OLEDBProvider, vUsername, vServer]);
+  GetuseIntegratedSecurity;
+
+  if Trim(vDriver) = '' then vDriver := DEFAULT_MYSQL_DRIVER;
+  if vPort = 0 then vPort := DEFAULT_MYSQL_PORT;
+
+  RetStr := Format('Provider=%s;Persist Security Info=False;Driver={%s};Server=%s;Port=%d',
+    [OLEDBProvider, vDriver, vServer, vPort]);
+
+  if vUsername <> '' then
+    RetStr := RetStr + Format(';User=%s', [vUsername]);
+
+  if vPassword <> '' then
+    RetStr := RetStr + Format(';Password=%s', [vPassword]);
+
+  if Pos('Option=', AnsiUpperCase(RetStr)) = 0 then
+    RetStr := RetStr + Format(';%s', [DEFAULT_ODBC_OPTIONS]);
+
+  if RetStr[Length(RetStr)] <> ';' then
+    RetStr := RetStr + ';';
+
   Result := RetStr;
 except
   on E:Exception do MessageDlg(e.Message, mtError, [mbOK], 0);
@@ -886,70 +962,12 @@ end;
 end; (*................................................................*)(*end*)(*...........................................*)
 
 function TSQLConnection.Database_Attach(FileName :string = ''): string;
-const
-  SQL_ATT = 'EXEC sp_attach_single_file_db @dbname = ''%s'', @physname = ''%s''';
-
-var
-  SQL_E     :TADOCommand;
-  dbName, dbPath    :string;
-  MyConn :TSetConnection;
-  StillProcess :boolean;
-
 begin (*.............................................................*)(*begin*)(*...........................................*)
 
-try
-  MyConn := TSetConnection.Create;
-  StillProcess := True;
-  Result := '-1';
-  SQL_E := TADOCommand.Create(Application);
-  with SQL_E do
-    try
-
-    if FileName = '' then
-      begin
-      with MyConn do
-        try
-        MyConn.Server := GetServer;
-        MyConn.Database := GetDatabase;
-        MyConn.UserName := GetUsername;
-        MyConn.Password := GetPassword;
-        MyConn.integratedSecurity := GetuseIntegratedSecurity;
-        MyConn.PhysicalFileName := GetdatabasePhysicalFileName;
-        MyConn.BackupPath := GetdatabaseBackupPath;
-        if MyConn.Connect(etSQL) then
-          begin
-          SetServer(MyConn.Server);
-          SetDatabase(MyConn.Database);
-          SetUsername(MyConn.UserName);
-          SetPassword(MyConn.Password);
-          SetdatabasePhysicalFileName(MyConn.PhysicalFileName);
-          SetdatabaseBackupPath(MyConn.BackupPath);
-          SetuseIntegratedSecurity(MyConn.integratedSecurity);
-          end else
-          StillProcess := False;
-        finally
-        Free;
-        end;
-      dbPath := GetdatabasePhysicalFileName;
-      end
-      else
-      dbPath := FileName;
-
-    if StillProcess then
-      begin
-      dbName := Getdatabase;
-      SQL_E.ConnectionString := BuildConnectionString_WithoutDB;
-      CommandText := Format(SQL_ATT, [dbName, dbPath]);
-      Execute;
-      OpenDatasets;
-      Result := '';
-      end;
-
-    finally
-    end;
-except
-  on E:Exception do MessageDlg(e.Message, mtError, [mbOK], 0);
-end;
+  Result := '';
+  MessageDlg('Automatic database attach operations are not supported for MySQL '
+    + 'connections. Restore the database using native MySQL tooling.',
+    mtInformation, [mbOK], 0);
 
 end;
 

--- a/Code/RxCommon/Classes/Class_Database_Connections_FrmConnect.pas
+++ b/Code/RxCommon/Classes/Class_Database_Connections_FrmConnect.pas
@@ -58,7 +58,7 @@ type
     FPassword: string;
     FFileName: string;
     FintegratedSecurity: Boolean;
-    FPhysicalFileName: string;
+    FPort: string;
     FBackupPath: string;
   public
     function Connect(Value:EEditFormType): Boolean;
@@ -69,8 +69,7 @@ type
     property FileName: string read FFileName write FFileName;
     property integratedSecurity: Boolean read FintegratedSecurity write
         FintegratedSecurity;
-    property PhysicalFileName: string read FPhysicalFileName write
-        FPhysicalFileName;
+    property Port: string read FPort write FPort;
     property BackupPath: string read FBackupPath write FBackupPath;
   end;
 
@@ -89,16 +88,23 @@ begin
   frmConnections := TfrmConnections.Create(Application);
   with frmConnections do
     try
+    Label8.Caption      := 'Port';
+    Label9.Visible      := False;
+    rzlBackupPath.Visible := False;
+    Button2.Visible     := False;
+    chbIntegratedSecurity.Visible := False;
+    chbIntegratedSecurity.Checked := False;
+    DisplayEditOptions;
     editFormType := Value;
     case Value of
       etSQL : begin
+              if Trim(FPort) = '' then
+                FPort := '3306';
               rzlServer.Text        := FServer;
               rzlDatabase.Text      := FDatabase;
               rzlUsername.Text      := FUsername;
               rzlPassword.Text      := FPassword;
-              rzlPhysicalFilename.Text := FPhysicalFileName;
-              rzlBackupPath.Text    := FBackupPath;
-              chbIntegratedSecurity.Checked := FIntegratedSecurity;
+              rzlPhysicalFilename.Text := FPort;
               end;
       etAccess : begin
 //              edtAccessFileName.Text  := FFileName;
@@ -117,9 +123,11 @@ begin
               FDatabase := rzlDatabase.Text;
               FUsername := rzlUsername.Text;
               FPassword := rzlPassword.Text;
-              FPhysicalFileName := rzlPhysicalFilename.Text;
-              FBackupPath := rzlBackupPath.Text;
-              FIntegratedSecurity := chbIntegratedSecurity.Checked;
+              FPort := rzlPhysicalFilename.Text;
+              if Trim(FPort) = '' then
+                FPort := '3306';
+              FBackupPath := '';
+              FIntegratedSecurity := False;
               end;
         etAccess : begin
 //              FFileName := edtAccessFileName.Text;

--- a/DispenserDLL.dproj
+++ b/DispenserDLL.dproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{7CFFEB95-4DEC-4B16-AC6E-245A0B9A29A3}</ProjectGuid>
+    <ProjectVersion>18.1</ProjectVersion>
+    <FrameworkType>VCL</FrameworkType>
+    <MainSource>DispenserDLL.dpr</MainSource>
+    <Base>True</Base>
+    <Config Condition="'$(Config)'==''">Release</Config>
+    <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    <TargetedPlatforms>1</TargetedPlatforms>
+    <AppType>Library</AppType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Debug'">
+    <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+    <DCC_DebugDCUs>true</DCC_DebugDCUs>
+    <DCC_Optimize>false</DCC_Optimize>
+    <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+    <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Release'">
+    <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+    <DCC_DebugInformation>0</DCC_DebugInformation>
+    <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+    <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    <DCC_Optimize>true</DCC_Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <DelphiCompile Include="DispenserDLL.dpr">
+      <MainSource>MainSource</MainSource>
+    </DelphiCompile>
+    <BuildConfiguration Include="Base">
+      <Key>Base</Key>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Debug">
+      <Key>Cfg_1</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Release">
+      <Key>Cfg_2</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+  </ItemGroup>
+  <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')" />
+</Project>

--- a/EvidenceDLL.dproj
+++ b/EvidenceDLL.dproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{2F82FDD7-9EC9-48B4-BF47-C75CEFC8F5FF}</ProjectGuid>
+    <ProjectVersion>18.1</ProjectVersion>
+    <FrameworkType>VCL</FrameworkType>
+    <MainSource>EvidenceDLL.dpr</MainSource>
+    <Base>True</Base>
+    <Config Condition="'$(Config)'==''">Release</Config>
+    <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    <TargetedPlatforms>1</TargetedPlatforms>
+    <AppType>Library</AppType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Debug'">
+    <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+    <DCC_DebugDCUs>true</DCC_DebugDCUs>
+    <DCC_Optimize>false</DCC_Optimize>
+    <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+    <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Release'">
+    <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+    <DCC_DebugInformation>0</DCC_DebugInformation>
+    <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+    <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    <DCC_Optimize>true</DCC_Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <DelphiCompile Include="EvidenceDLL.dpr">
+      <MainSource>MainSource</MainSource>
+    </DelphiCompile>
+    <BuildConfiguration Include="Base">
+      <Key>Base</Key>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Debug">
+      <Key>Cfg_1</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Release">
+      <Key>Cfg_2</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+  </ItemGroup>
+  <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')" />
+</Project>

--- a/PrescriberDLL.dproj
+++ b/PrescriberDLL.dproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{A53E4A2E-D3F6-434D-8AB2-4E97207CD7CF}</ProjectGuid>
+    <ProjectVersion>18.1</ProjectVersion>
+    <FrameworkType>VCL</FrameworkType>
+    <MainSource>PrescriberDLL.dpr</MainSource>
+    <Base>True</Base>
+    <Config Condition="'$(Config)'==''">Release</Config>
+    <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    <TargetedPlatforms>1</TargetedPlatforms>
+    <AppType>Library</AppType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Debug'">
+    <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+    <DCC_DebugDCUs>true</DCC_DebugDCUs>
+    <DCC_Optimize>false</DCC_Optimize>
+    <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+    <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Release'">
+    <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+    <DCC_DebugInformation>0</DCC_DebugInformation>
+    <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+    <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    <DCC_Optimize>true</DCC_Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <DelphiCompile Include="PrescriberDLL.dpr">
+      <MainSource>MainSource</MainSource>
+    </DelphiCompile>
+    <BuildConfiguration Include="Base">
+      <Key>Base</Key>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Debug">
+      <Key>Cfg_1</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Release">
+      <Key>Cfg_2</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+  </ItemGroup>
+  <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')" />
+</Project>

--- a/Prescription.dproj
+++ b/Prescription.dproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{1DD4A431-099E-4BA2-8629-44510FD2B50B}</ProjectGuid>
+    <ProjectVersion>18.1</ProjectVersion>
+    <FrameworkType>VCL</FrameworkType>
+    <MainSource>Prescription.dpr</MainSource>
+    <Base>True</Base>
+    <Config Condition="'$(Config)'==''">Release</Config>
+    <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    <TargetedPlatforms>1</TargetedPlatforms>
+    <AppType>Library</AppType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Debug'">
+    <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+    <DCC_DebugDCUs>true</DCC_DebugDCUs>
+    <DCC_Optimize>false</DCC_Optimize>
+    <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+    <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Release'">
+    <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+    <DCC_DebugInformation>0</DCC_DebugInformation>
+    <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+    <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    <DCC_Optimize>true</DCC_Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <DelphiCompile Include="Prescription.dpr">
+      <MainSource>MainSource</MainSource>
+    </DelphiCompile>
+    <BuildConfiguration Include="Base">
+      <Key>Base</Key>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Debug">
+      <Key>Cfg_1</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Release">
+      <Key>Cfg_2</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+  </ItemGroup>
+  <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')" />
+</Project>

--- a/PrintDLL.dproj
+++ b/PrintDLL.dproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{346CA764-628A-4644-B037-10BAB7CFD705}</ProjectGuid>
+    <ProjectVersion>18.1</ProjectVersion>
+    <FrameworkType>VCL</FrameworkType>
+    <MainSource>PrintDLL.dpr</MainSource>
+    <Base>True</Base>
+    <Config Condition="'$(Config)'==''">Release</Config>
+    <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    <TargetedPlatforms>1</TargetedPlatforms>
+    <AppType>Library</AppType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Debug'">
+    <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+    <DCC_DebugDCUs>true</DCC_DebugDCUs>
+    <DCC_Optimize>false</DCC_Optimize>
+    <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+    <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Release'">
+    <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+    <DCC_DebugInformation>0</DCC_DebugInformation>
+    <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+    <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    <DCC_Optimize>true</DCC_Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <DelphiCompile Include="PrintDLL.dpr">
+      <MainSource>MainSource</MainSource>
+    </DelphiCompile>
+    <BuildConfiguration Include="Base">
+      <Key>Base</Key>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Debug">
+      <Key>Cfg_1</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Release">
+      <Key>Cfg_2</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+  </ItemGroup>
+  <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')" />
+</Project>

--- a/README.md
+++ b/README.md
@@ -9,4 +9,12 @@ The RxSolution software, documentation and other products, information, material
 
 Special note for developers: The source code was developed using Delphi 7 and Plugins. The QuantumGrid v3.22 is required but no longer available. This means that a manual conversion of tables from Tdx to Tcx has to be performed. Please follow the advise here from the plugin developers: https://www.devexpress.com/Support/Center/Question/Details/DQ13868/convert-from-tdxdbgrid-v3-to-the-new-v5
 
+## Modern IDE support
+
+The repository now includes MSBuild-compatible project files (`*.dproj` and `RxSolution.groupproj`) so the application and its auxiliary DLLs can be loaded directly in modern versions of Delphi / RAD Studio without relying on the legacy Borland project group format.
+
+## Database connectivity
+
+The legacy SQL Server specific connection logic has been replaced with a MySQL implementation that relies on the MySQL ODBC driver via ADO. Provide the server, database, user name, password, and optional port when prompted inside the application. Automated SQL Server backup and attach commands have been removed; use MySQL-native tooling for those operations.
+
 Copyright Management Sciences for Health.

--- a/RxSolution.dproj
+++ b/RxSolution.dproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{1C949C22-8AAC-4558-BE8B-AED583526661}</ProjectGuid>
+    <ProjectVersion>18.1</ProjectVersion>
+    <FrameworkType>VCL</FrameworkType>
+    <MainSource>RxSolution.dpr</MainSource>
+    <Base>True</Base>
+    <Config Condition="'$(Config)'==''">Release</Config>
+    <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    <TargetedPlatforms>1</TargetedPlatforms>
+    <AppType>Application</AppType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Debug'">
+    <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+    <DCC_DebugDCUs>true</DCC_DebugDCUs>
+    <DCC_Optimize>false</DCC_Optimize>
+    <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+    <DCC_DebugInfoInExe>true</DCC_DebugInfoInExe>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Config)'=='Release'">
+    <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+    <DCC_DebugInformation>0</DCC_DebugInformation>
+    <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+    <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    <DCC_Optimize>true</DCC_Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <DelphiCompile Include="RxSolution.dpr">
+      <MainSource>MainSource</MainSource>
+    </DelphiCompile>
+    <BuildConfiguration Include="Base">
+      <Key>Base</Key>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Debug">
+      <Key>Cfg_1</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+    <BuildConfiguration Include="Release">
+      <Key>Cfg_2</Key>
+      <CfgParent>Base</CfgParent>
+    </BuildConfiguration>
+  </ItemGroup>
+  <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')" />
+</Project>

--- a/RxSolution.groupproj
+++ b/RxSolution.groupproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Projects Include="RxSolution.dproj">
+      <Dependencies />
+    </Projects>
+    <Projects Include="DispenserDLL.dproj">
+      <Dependencies />
+    </Projects>
+    <Projects Include="PrescriberDLL.dproj">
+      <Dependencies />
+    </Projects>
+    <Projects Include="PrintDLL.dproj">
+      <Dependencies />
+    </Projects>
+    <Projects Include="EvidenceDLL.dproj">
+      <Dependencies />
+    </Projects>
+    <Projects Include="Prescription.dproj">
+      <Dependencies />
+    </Projects>
+  </ItemGroup>
+  <ProjectExtensions>
+    <Borland.Personality>Default.Personality</Borland.Personality>
+    <Borland.ProjectType>ProjectGroup</Borland.ProjectType>
+    <BorlandProject>
+      <Default.Personality />
+    </BorlandProject>
+  </ProjectExtensions>
+</Project>


### PR DESCRIPTION
## Summary
- switch the ADO connection layer to build MySQL connection strings, expose driver/port configuration, and remove SQL Server specific backup/attach routines
- refresh the connection dialog to capture MySQL credentials and hide unsupported SQL Server options
- add MSBuild-compatible project and group files so the solution opens in modern Delphi IDEs, and update the README with MySQL usage guidance

## Testing
- not run (Delphi project)


------
https://chatgpt.com/codex/tasks/task_e_68e00a90abdc832da7b9cd1bf4406890